### PR TITLE
Added support to load in a list of xml files

### DIFF
--- a/src/dtscalibration/__init__.py
+++ b/src/dtscalibration/__init__.py
@@ -2,6 +2,7 @@
 from .datastore import DataStore
 from .datastore import open_datastore
 from .datastore import read_xml_dir
+from .datastore import read_xml_list
 
 __version__ = '0.5.0'
-__all__ = ["DataStore", "open_datastore", "read_xml_dir"]
+__all__ = ["DataStore", "open_datastore", "read_xml_dir", "read_xml_list"]

--- a/src/dtscalibration/datastore.py
+++ b/src/dtscalibration/datastore.py
@@ -1312,7 +1312,7 @@ def open_datastore(filename_or_obj, group=None, decode_cf=True,
 
 def read_xml_dir(filepath,
                  timezone_netcdf='UTC',
-                 timezone_ultima_xml='Europe/Amsterdam',
+                 timezone_ultima_xml='UTC',
                  file_ext='*.xml',
                  **kwargs):
     """Read a folder with measurement files. Each measurement file contains values for a
@@ -1338,13 +1338,19 @@ def read_xml_dir(filepath,
         The newly created datastore.
     """
 
+    # Get list of files in the given path
     filepathlist = sorted(glob.glob(os.path.join(filepath, file_ext)))
+
+    # Get the file names of each file, without the path
     filenamelist = [os.path.basename(path) for path in filepathlist]
+
+    # Make sure that there are files in the folder, to avoid errors later
     assert len(filepathlist) >= 1, 'No measurement files with extension {} found in {}'.format(
         file_ext, filepath)
 
+    # Use the read_xml_list function to read all files
     ds = read_xml_list(filepathlist, timezone_netcdf, timezone_ultima_xml)
-    
+
     return ds
 
 def read_xml_list(filepathlist,
@@ -1404,12 +1410,13 @@ def read_xml_list(filepathlist,
             'long_describtion': 'Desired measurement duration of backward channel',
             'units':            'seconds'},
         }
-    
-    #Get list of only file names, from the path
+    # Make sure that the list of files contains any files
+    assert len(filepathlist) >= 1, 'No measurement files found in provided list'
+
+    # Get list of only file names, from the path
     filenamelist = [os.path.basename(path) for path in filepathlist]
-    assert len(filepathlist) >= 1, 'No measurement files found in {}'.format(filepath)
-    
-    #Call grab_data2 to read out all files
+
+    # Call grab_data2 to read out all files
     array, timearr, meta, extra = grab_data2(filepathlist)
 
     coords = {

--- a/src/dtscalibration/datastore.py
+++ b/src/dtscalibration/datastore.py
@@ -1337,6 +1337,40 @@ def read_xml_dir(filepath,
     datastore : DataStore
         The newly created datastore.
     """
+
+    filepathlist = sorted(glob.glob(os.path.join(filepath, file_ext)))
+    filenamelist = [os.path.basename(path) for path in filepathlist]
+    assert len(filepathlist) >= 1, 'No measurement files with extension {} found in {}'.format(
+        file_ext, filepath)
+
+    ds = read_xml_list(filepathlist, timezone_netcdf, timezone_ultima_xml)
+    
+    return ds
+
+def read_xml_list(filepathlist,
+                  timezone_netcdf='UTC',
+                  timezone_ultima_xml='UTC',
+                  **kwargs):
+    """Read a list of measurement files. Each measurement file contains values for a
+    single timestep. Remember to check which timezone you are working in.
+
+    Parameters
+    ----------
+    filenamelist : list, Path
+        List of paths to files
+    timezone_netcdf : str, optional
+        Timezone string of the netcdf file. UTC follows CF-conventions.
+    timezone_ultima_xml : str, optional
+        Timezone string of the measurement files. Remember to check when measurements are taken.
+        Also if summertime is used.
+    kwargs : dict-like, optional
+        keyword-arguments are passed to DataStore initialization
+
+    Returns
+    -------
+    datastore : DataStore
+        The newly created datastore.
+    """
     log_attrs = {
         'x':                     {
             'description':      'Length along fiber',
@@ -1370,12 +1404,12 @@ def read_xml_dir(filepath,
             'long_describtion': 'Desired measurement duration of backward channel',
             'units':            'seconds'},
         }
-
-    filepathlist = sorted(glob.glob(os.path.join(filepath, file_ext)))
+    
+    #Get list of only file names, from the path
     filenamelist = [os.path.basename(path) for path in filepathlist]
-    assert len(filepathlist) >= 1, 'No measurement files with extension {} found in {}'.format(
-        file_ext, filepath)
-
+    assert len(filepathlist) >= 1, 'No measurement files found in {}'.format(filepath)
+    
+    #Call grab_data2 to read out all files
     array, timearr, meta, extra = grab_data2(filepathlist)
 
     coords = {


### PR DESCRIPTION
Instead of only allowing a directory to be given, this allows a list of xml files to be loaded in. The read_xml_dir function has been linked through to the read_xml_list function, to avoid code duplicates.